### PR TITLE
Expand installation instructions to cover macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# The NuttX Companion
+# The Apache NuttX Companion
 
-This is the [NuttX Companion](https://nuttx-companion.readthedocs.io), a warm and friendly guide to all 
-things [NuttX](https://nuttx.apache.org)– how to install it, configure it, develop on it, debug it, improve 
+This is the [Apache NuttX Companion](https://nuttx-companion.readthedocs.io), a warm and friendly guide to all 
+things [Apache NuttX](https://nuttx.apache.org)– how to install it, configure it, develop on it, debug it, improve 
 it, get help from its community, and generally have fun with this very capable, configurable,
 fast, POSIX-compatible, internet-connected real-time operating system.
 
-Hopefully this guide will complement the NuttX documentation, filling in gaps when needed, and
+Hopefully this guide will complement the Apache NuttX documentation, filling in gaps when needed, and
 providing more help for people interested in learning about NuttX.
 
-You can see the HTML version of this book here: [NuttX Companion](https://nuttx-companion.readthedocs.io).
+You can see the HTML version of this book here: [Apache NuttX Companion](https://nuttx-companion.readthedocs.io).
 
 ## Building the Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. include:: /substitutions.rst
 .. _index:
 
-The NuttX Companion
+The Apache NuttX Companion
 ===================
 
 Release v\ |version|. (:ref:`Quickstart <quickstart>`)
@@ -10,12 +10,12 @@ Release v\ |version|. (:ref:`Quickstart <quickstart>`)
    :maxdepth: 2
    :caption: Contents:
 
-`NuttX <https://nuttx.incubator.apache.org/>`_ is a very capable, configurable, fast,
+`Apache NuttX <https://nuttx.incubator.apache.org/>`_ is a very capable, configurable, fast,
 `POSIX <https://en.wikipedia.org/wiki/POSIX>`_-compatible, internet-connected
 `real-time operating system <https://en.wikipedia.org/wiki/Real-time_operating_system>`_.
 
-This book is meant to be a companion to the `NuttX Documentation <https://cwiki.apache.org/confluence/display/NUTTX/Nuttx>`_. Hopefully it will provide
-some more help for people interested in learning about NuttX, getting it running on their embedded hardware, and developing applications on it.
+This book is meant to be a companion to the `Apache NuttX Documentation <https://cwiki.apache.org/confluence/display/NUTTX/Nuttx>`_. Hopefully it will provide
+some more help for people interested in learning about Apache NuttX, getting it running on their embedded hardware, and developing applications on it.
 
 
 User Guide

--- a/docs/user/compiling.rst
+++ b/docs/user/compiling.rst
@@ -4,13 +4,13 @@
 Compiling
 =========
 
-Now that we've installed NuttX prerequisites and downloaded the source code, we are ready to compile the source code
+Now that we've installed Apache NuttX prerequisites and downloaded the source code, we are ready to compile the source code
 into an executable binary file that can be run on the embedded board.
 
-#. List Possible NuttX Base Configurations
+#. List Possible Apache NuttX Base Configurations
 
    Find your hardware and a good starting application in the list of base configurations. In the application list,
-   ``nsh`` is the NuttX Shell, an interactive commandline that's a good starting place if you're new.
+   ``nsh`` is the Apache NuttX Shell, an interactive commandline that's a good starting place if you're new.
 
     .. code-block:: bash
 
@@ -51,4 +51,4 @@ into an executable binary file that can be run on the embedded board.
 #. Install the Executable Program on Your Board
 
    This step is a bit more complicated, depending on your board. It's covered in the section
-   :ref:`Running NuttX <running>`.
+   :ref:`Running Apache NuttX <running>`.

--- a/docs/user/configuring.rst
+++ b/docs/user/configuring.rst
@@ -4,17 +4,17 @@
 Configuring
 ===========
 
-NuttX is a very configurable operating system. Nearly all features can be configured in or
+Apache NuttX is a very configurable operating system. Nearly all features can be configured in or
 out of the system. This makes it possible to compile a build tailored for your hardware and
 application. It also makes configuring the system complex at times.
 
 There is a configuration system that can be used on the commandline or in a GUI. I've found
-the easiest way to configured NuttX is to use the ``menuconfig`` system. This is used
-via a terminal program and allows quick access to all of NuttX's features via a system of
+the easiest way to configured Apache NuttX is to use the ``menuconfig`` system. This is used
+via a terminal program and allows quick access to all of Apache NuttX's features via a system of
 menus.
 
-The NuttX configuration system uses Linux's
-`kconfig system <https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_ adapted for use with NuttX.
+The Apache NuttX configuration system uses Linux's
+`kconfig system <https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_ adapted for use with Apache NuttX.
 Here's info on Linux's kconfig `menuconfig <https://en.wikipedia.org/wiki/Menuconfig>`_ system.
 
 After you've configured your board (see :ref:`compiling`), you can use the menuconfig system

--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -4,16 +4,16 @@
 Contributing
 ============
 
-The NuttX Companion is made using the
+The Apache NuttX Companion is made using the
 `Sphinx documentation system <https://www.sphinx-doc.org/en/master/>`_. Sphinx documentation
 is written in `ReStructured Text <https://docutils.sourceforge.io/rst.html>`_ (RST). RST is
 the format used for `Python documentation <https://docs.python.org/3/>`_ and is also used
 in many other projects.
 
-Contributions and fixes to the NuttX Companion are encouraged and welcome. Here's how to do
+Contributions and fixes to the Apache NuttX Companion are encouraged and welcome. Here's how to do
 it.
 
-#. Fork the NuttX Companion Repository
+#. Fork the Apache NuttX Companion Repository
 
    Visit this link and hit the Fork button in the upper right of the page:
 
@@ -120,7 +120,7 @@ it.
 
 #. Submit Your Pull Request
 
-   Go to the `NuttX Companion <https://github.com/adamfeuer/nuttx-companion/>`_ page
+   Go to the `Apache NuttX Companion <https://github.com/adamfeuer/nuttx-companion/>`_ page
    on Github and click the "Pull Request" button. See Github's `Creating a Pull Request
    <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request>`__
    page for more info.
@@ -146,7 +146,7 @@ it.
 
 #. Make Changes If Requested
 
-   When you submit your Pull Request, the NuttX Companion team will review the changes,
+   When you submit your Pull Request, the Apache NuttX Companion team will review the changes,
    and may request that you modify your submission. Please work with them to get your
    changes accepted.
    |br|
@@ -154,7 +154,7 @@ it.
 
 #. You're Done!
 
-   Feel good that you've made NuttX documentation better for yourself and others. You've
+   Feel good that you've made Apache NuttX documentation better for yourself and others. You've
    just made the world a better place!
 
 Sphinx Resources

--- a/docs/user/debugging.rst
+++ b/docs/user/debugging.rst
@@ -100,6 +100,6 @@ You'll need to use the `Sony fork of OpenOCD <https://github.com/sony/openocd-nu
 according to the OpenOCD instructions.
 
 See this article for more info:
-`Debugging a NuttX target with GDB and OpenOCD <https://micro-ros.github.io/docs/tutorials/advanced/debugging_gdb_openocd/>`_.
+`Debugging a Apache NuttX target with GDB and OpenOCD <https://micro-ros.github.io/docs/tutorials/advanced/debugging_gdb_openocd/>`_.
 
 

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -4,37 +4,107 @@
 Installing
 ==========
 
-To start developing on NuttX, we need to get the source code, configure it, compile it, and get it uploaded onto an
-embedded computing board. These instructions are for `Ubuntu <https://ubuntu.com/>`_ Linux. If you're using a different
+To start developing on Apache NuttX, we need to get the source code, configure it, compile it, and get it uploaded onto an
+embedded computing board. These instructions are for `Ubuntu <https://ubuntu.com/>`_ Linux and macOS Catalina. If you're using a different
 version, you may need to change some of the commands.
 
-Install Prerequisites
+Prerequisites
 ---------------------
 
-#. Install prerequisites for building and using NuttX
+Install prerequisites for building and using Apache NuttX (Linux)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#. Install system packages
 
-    .. code-block:: bash
+ .. code-block:: bash
 
-       $ sudo apt install bison flex gettext texinfo libncurses5-dev libncursesw5-dev
-       $ sudo apt install gperf automake libtool pkg-config build-essential gperf
-       $ sudo apt insatll libgmp-dev libmpc-dev libmpfr-dev libisl-dev binutils-dev libelf-dev
-       $ sudo apt install libexpat-dev gcc-multilib g++-multilib picocom u-boot-tools
+    $ sudo apt install \
+        bison flex gettext texinfo libncurses5-dev libncursesw5-dev \
+        gperf automake libtool pkg-config build-essential gperf \
+        libgmp-dev libmpc-dev libmpfr-dev libisl-dev binutils-dev libelf-dev \
+        libexpat-dev gcc-multilib g++-multilib picocom u-boot-tools util-linux
+
 
 #. Give yourself access to the serial console device
 
    This is done by adding your Linux user to the ``dialout`` group:
 
-    .. code-block:: bash
+ .. code-block:: bash
 
-       $ sudo usermod -a -G dialout $USER
-       $ # now get a login shell that knows we're in the dialout group:
-       $ su - $USER
+    $ sudo usermod -a -G dialout $USER
+    $ # now get a login shell that knows we're in the dialout group:
+    $ su - $USER
+
+Install prerequisites for building and using Apache NuttX (macOS)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ .. code-block:: bash
+
+    $ brew tap discoteq/discoteq
+    $ brew install flock
+    $ brew install x86_64-elf-gcc  # Used by simulator
+    $ brew install u-boot-tools  # Some platform integrate with u-boot
 
 
-Get the Source Code
--------------------
+Install Required Tools
+~~~~~~~~~~~~~~~~~~~~~~
 
-NuttX is `actively developed on GitHub <https://github.com/apache/incubator-nuttx/>`_. If you want
+There are a collection of required tools that need to be built to build most Apache NuttX configurations:
+
+ .. code-block:: bash
+
+    $ mkdir buildtools
+    $ export NUTTXTOOLS=`pwd`/buildtools
+    $ export NUTTXTOOLS_PATH=$NUTTXTOOLS/bin:$NUTTXTOOLS/usr/bin
+    $ git clone https://bitbucket.org/nuttx/tools.git tools
+
+*NOTE:* You will need to add ``NUTTXTOOLS_PATH`` to your environment ``PATH``
+
+#. Install kconfig-frontends tool
+
+This is necessary to run the ``./nuttx/tools/configure.sh`` script as well as using the ncurses-based menuconfig system.
+
+ .. code-block:: bash
+
+    $ cd tools/
+    $ cd kconfig-frontends
+    $ ./configure --prefix=$NUTTXTOOLS \
+         --disable-kconfig --disable-nconf --disable-qconf \
+         --disable-gconf --disable-mconf --disable-static \
+         --disable-shared --disable-L10n --disable-utils
+    $ touch aclocal.m4 Makefile.in
+    $ make
+    $ make install
+
+#. Install gperf tool (optional)
+
+ .. code-block:: bash
+
+    $ cd tools/
+    $ tar zxf gperf-3.1.tar.gz
+    $ cd gperf-3.1
+    $ ./configure --prefix=$NUTTXTOOLS
+    $ make
+    $ make install
+
+#. Install gen-romfs (optional)
+
+
+ .. code-block:: bash
+
+    $ cd tools/
+    $ tar zxf genromfs-0.5.2.tar.gz
+    $ cd genromfs
+    $ make install PREFIX=$NUTTXTOOLS
+
+Get Source Code (Stable)
+------------------------
+Apache NuttX releases are published on the project `Downloads <https://nuttx.apache.org/download/>`_ page and distributed
+by the Apache mirrors.  Be sure to download both the nuttx and apps tarballs.
+
+
+Get Source Code (Developement)
+------------------------------
+Apache NuttX is `actively developed on GitHub <https://github.com/apache/incubator-nuttx/>`_. If you want
 to use it, modify it or help develop it, you'll need the source code.
 
 You can either clone the public repositories:
@@ -45,7 +115,6 @@ You can either clone the public repositories:
        $ cd nuttx
        $ git clone https://github.com/apache/incubator-nuttx.git nuttx
        $ git clone https://github.com/apache/incubator-nuttx-apps apps
-       $ git clone https://bitbucket.org/nuttx/tools.git tools
 
 Or, download the `tarball <https://github.com/apache/incubator-nuttx/tarball/master>`_:
 
@@ -59,25 +128,15 @@ Later if we want to make modifications (for instance, to improve NuttX and save 
 or submit them back to the project), we can do that easily. It's covered in the section
 :ref:`Making Changes <making-changes>`.
 
-#. Install kconfig-frontends tool
-
-This is necessary to run the ``./nuttx/tools/configure.sh`` script as well as using the ncurses-based menuconfig system.
-
-    .. code-block:: bash
-
-       $ cd tools/
-       $ cd kconfig-frontends
-       $ ./configure --enable-mconf
-       $ make
-       $ sudo make install
-       $ sudo ldconfig
-
 Install a Cross-Compiler Toolchain
 ----------------------------------
 
-With NuttX, you compile the operating system and your application on your desktop or laptop computer, then install the
+With Apache NuttX, you compile the operating system and your application on your desktop or laptop computer, then install the
 binary file on your embedded computer. This guide assumes your computer is an
 `ARM <https://en.wikipedia.org/wiki/ARM_architecture>`_ CPU. If it isn't, you'll need a different tool chain.
+
+   There are hints on how to get the latest tool chains for most supported architectures in the Apache NuttX CI helper
+   `script <https://github.com/apache/incubator-nuttx-testing/blob/master/cibuild.sh>`_ and Docker `container <https://github.com/apache/incubator-nuttx-testing/blob/master/docker/linux/Dockerfile>`_
 
 Download the right flavor of the
 `ARM Embedded Gnu Toolchain <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm>`_
@@ -85,19 +144,18 @@ for your embedded processor's CPU.
 
 Unpack it into ``/opt/gcc`` and add the bin directory to your path. For instance:
 
-    .. code-block:: bash
+ .. code-block:: bash
 
-       $ usermod -a -G users $USER
-       $ # get a login shell that knows we're in this group:
-       $ su - $USER
-       $ sudo mkdir /opt/gcc
-       $ sudo chgrp -R users /opt/gcc
-       $ sudo chmod -R u+rw /opt/gcc
-       $ cd /opt/gcc
-       $ curl -L -o gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D
-       $ tar xf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
-       $ # add the toolchain bin/ dir to your path...
-       $ # you can edit your shell's rc files if you don't use bash
-       $ echo "export PATH=/opt/gcc/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH" >> ~/.bashrc
-
-
+    $ usermod -a -G users $USER
+    $ # get a login shell that knows we're in this group:
+    $ su - $USER
+    $ sudo mkdir /opt/gcc
+    $ sudo chgrp -R users /opt/gcc
+    $ sudo chmod -R u+rw /opt/gcc
+    $ cd /opt/gcc
+    $ HOST_PLATFORM=x86_64-linux   # use "mac" for macOS
+    $ curl -L -o gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2
+    $ tar xf gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2
+    $ # add the toolchain bin/ dir to your path...
+    $ # you can edit your shell's rc files if you don't use bash
+    $ echo "export PATH=/opt/gcc/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH" >> ~/.bashrc

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -4,14 +4,14 @@
 Introduction
 ============
 
-This is the NuttX Companion, a warm and friendly guide to all things NuttX– how to install it,
+This is the Apache NuttX Companion, a warm and friendly guide to all things Apache NuttX– how to install it,
 configure it, develop on it, debug it, improve it, get help from its community, and generally 
 be have fun with a very capable, configurable, fast,
 `POSIX <https://en.wikipedia.org/wiki/POSIX>`_-compatible, internet-connected
 `real-time operating system <https://en.wikipedia.org/wiki/Real-time_operating_system>`_.
 
-Hopefully this guide will complement the NuttX documentation, filling in gaps when needed, and 
-providing help for people wanting to get started with NuttX.
+Hopefully this guide will complement the Apache NuttX documentation, filling in gaps when needed, and 
+providing help for people wanting to get started with Apache NuttX.
 
 If you have improvements, corrections, additions, or things you'd like to see covered here,
 let me know! Contributions to this Companion are also welcome and encouraged! See the section

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -32,7 +32,7 @@ computer, you're using an ARM processor on your embedded board, and you're famil
        $ echo "export PATH=/opt/gcc/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH" >> ~/.bashrc
 
 
-#. Download NuttX
+#. Download Apache NuttX
 
     .. code-block:: bash
 
@@ -41,10 +41,10 @@ computer, you're using an ARM processor on your embedded board, and you're famil
        $ git clone https://github.com/apache/incubator-nuttx.git nuttx
        $ git clone https://github.com/apache/incubator-nuttx-apps apps
 
-#. List Possible NuttX Base Configurations
+#. List Possible Apache NuttX Base Configurations
 
    Find your hardware and a good starting application in the list of base configurations. In the application list,
-   ``nsh`` is the NuttX Shell, an interactive commandline that's a good starting place if you're new.
+   ``nsh`` is the Apache NuttX Shell, an interactive commandline that's a good starting place if you're new.
 
     .. code-block:: bash
 
@@ -74,7 +74,7 @@ computer, you're using an ARM processor on your embedded board, and you're famil
        $ make menuconfig
 
 
-#. Compile NuttX
+#. Compile Apache NuttX
 
     .. code-block:: bash
 
@@ -83,4 +83,4 @@ computer, you're using an ARM processor on your embedded board, and you're famil
 #. Install the Executable Program on Your Board
 
    This step is a bit more complicated, depending on your board. It's covered in the section
-   :ref:`Running NuttX <running>`.
+   :ref:`Running Apache NuttX <running>`.

--- a/docs/user/resources.rst
+++ b/docs/user/resources.rst
@@ -4,16 +4,16 @@
 Resources
 =========
 
-Here's a list of NuttX resources that you might find helpful:
+Here's a list of Apache NuttX resources that you might find helpful:
 
- * NuttX
+ * Apache NuttX
 
-   * `NuttX website <https://www.nuttx.org>`_
-   * `NuttX online documentation <https://cwiki.apache.org/confluence/display/NUTTX/Nuttx>`_
-   * `NuttX mailing list <https://nuttx.incubator.apache.org/community/>`_ – a very active mailing list, the place to get help with your application or any questions you have about NuttX.
-   * `NuttX YouTube channel <https://www.youtube.com/channel/UC0QciIlcUnjJkL5yJJBmluw/videos>`_ – Alan Carvalho de Assis's YouTube channel on NuttX. It's a source of a lot of great practical information.
-   * `NuttX Coding Standard <https://cwiki.apache.org/confluence/display/NUTTX/Coding+Standard>`_ — How code should look when you submit new files or modify existing ones.
-   * `NuttX Code Contribution Guidlines <https://cwiki.apache.org/confluence/display/NUTTX/Code+Contribution+Workflow+--+Brennan+Ashton>`_ — The full workflow to follow for submitting code with all the details.
+   * `Apache NuttX website <https://www.nuttx.org>`_
+   * `Apache NuttX online documentation <https://cwiki.apache.org/confluence/display/NUTTX/Nuttx>`_
+   * `Apache NuttX mailing list <https://nuttx.incubator.apache.org/community/>`_ – a very active mailing list, the place to get help with your application or any questions you have about NuttX.
+   * `Apache NuttX YouTube channel <https://www.youtube.com/channel/UC0QciIlcUnjJkL5yJJBmluw/videos>`_ – Alan Carvalho de Assis's YouTube channel on NuttX. It's a source of a lot of great practical information.
+   * `Apache NuttX Coding Standard <https://cwiki.apache.org/confluence/display/NUTTX/Coding+Standard>`_ — How code should look when you submit new files or modify existing ones.
+   * `Apache NuttX Code Contribution Guidlines <https://cwiki.apache.org/confluence/display/NUTTX/Code+Contribution+Workflow+--+Brennan+Ashton>`_ — The full workflow to follow for submitting code with all the details.
 
  * Git
 

--- a/docs/user/running.rst
+++ b/docs/user/running.rst
@@ -40,7 +40,7 @@ You can load code, start, stop, step through the program, and examine variables 
 #. Connect to the board's serial console
 
    Usually you connect a USB-to-serial adapter to the board's serial console so you can see debug logging or
-   execute NuttX Shell (nsh) commands. You can access the serial console from Linux with the ``picocom`` terminal
+   execute Apache NuttX Shell (nsh) commands. You can access the serial console from Linux with the ``picocom`` terminal
    program:
 
     .. code-block:: bash

--- a/docs/user/simulator.rst
+++ b/docs/user/simulator.rst
@@ -4,10 +4,10 @@
 Simulator
 =========
 
-NuttX has a simulator that can run as a regular program on Linux, Mac, and Windows computers.
+Apache NuttX has a simulator that can run as a regular program on Linux, Mac, and Windows computers.
 It's useful for debugging operating system features that aren't associated with particular
 device drivers— for instance the TCP/IP stack itself, a web interface or API for your
-application, or other communication protocols. It's also handy for trying out NuttX without
+application, or other communication protocols. It's also handy for trying out Apache NuttX without
 having a piece of embedded hardware.
 
 This guide assumes you're on Linux. It works on Windows and Mac too— if you know how,
@@ -55,7 +55,7 @@ Running
 
 #. Bring Up the Network Interfaces
 
-   On NuttX:
+   On Apache NuttX:
 
     .. code-block:: bash
 
@@ -90,7 +90,7 @@ Running
    need to pick the one that's right for your system.
 
    Then, on Linux do this to set up the tap network interface and route that will let
-   the Nuttx simulator access the network:
+   the Apache Nuttx simulator access the network:
 
     .. code-block:: bash
 
@@ -103,7 +103,7 @@ Running
        1 packets transmitted, 1 received, 0% packet loss, time 0ms
        rtt min/avg/max/mdev = 7.529/7.529/7.529/0.000 m
 
-#. Test that NuttX can access the Internet
+#. Test that Apache NuttX can access the Internet
 
    First let's ping the network interface of our Linux host to prove we can see the
    gateway to the Internet:


### PR DESCRIPTION
Expand installation instructions to cover macOS

 * This also hopefully cleans up some of the tool installation.
 * Adds some hints on where to find the toolchains being used.
 * Updates references to Apache NuttX

Signed-off-by: Brennan Ashton <bashton@brennanashton.com>