### PR TITLE
Update config flags for kconfig-frontends

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -92,9 +92,7 @@ This is necessary to run the ``./nuttx/tools/configure.sh`` script as well as us
     $ cd tools/
     $ cd kconfig-frontends
     $ ./configure --prefix=$NUTTXTOOLS \
-         --disable-kconfig --disable-nconf --disable-qconf \
-         --disable-gconf --disable-static --disable-shared \
-         --disable-L10n --disable-utils
+         --enable-mconf --disable-gconf --disable-qconf
     $ touch aclocal.m4 Makefile.in
     $ make
     $ make install


### PR DESCRIPTION
The config flags that were given are not appropriate for and interactive development and were also preventing kconfig-tweak which is now a requirement as well.